### PR TITLE
Not create the folder, otherwise the link can't be done

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER "Greg Gigon @ https://github.com/greggigon"
 ADD apacheds.sh /usr/local/bin/	
 
 RUN yum -y update && yum -y install java-1.7.0-openjdk openldap-clients && curl -s http://mirrors.ukfast.co.uk/sites/ftp.apache.org//directory/apacheds/dist/2.0.0-M20/apacheds-2.0.0-M20-x86_64.rpm -o /tmp/apacheds.rpm \
-	&& yum -y localinstall /tmp/apacheds.rpm && rm -rf /tmp/apacheds.rpm && mkdir -p /data && mkdir -p /bootstrap \
+	&& yum -y localinstall /tmp/apacheds.rpm && rm -rf /tmp/apacheds.rpm && mkdir -p /bootstrap \
 	&& ln -s /var/lib/apacheds-2.0.0_M20/default/partitions /data && chmod +x /usr/local/bin/apacheds.sh \
 	&& chown -R apacheds.apacheds /data && chown -R apacheds.apacheds /var/lib/apacheds-2.0.0_M20/default/partitions
 


### PR DESCRIPTION
If we create the folder the link can't be done and data is not available on the volume. I still think that it may not work because data should be in /ldap, so maybe it would be better to change that the folder shared is /var/lib/apacheds-2.0.0_M20/
