### PR TITLE
check for config.ldif_migrated so that we don't try to reconfigure LDAP when restarting the docker image.

### DIFF
--- a/apacheds.sh
+++ b/apacheds.sh
@@ -19,7 +19,7 @@ function wait_for_ldap {
     done 
 }
 
-if [ -f /bootstrap/config.ldif ]; then
+if [ -f /bootstrap/config.ldif ] && [ ! -f /var/lib/apacheds-2.0.0_M20/default/conf/config.ldif_migrated ]; then
 	echo "Using config file from /bootstrap/config.ldif"
 	rm -rf /var/lib/apacheds-2.0.0_M20/default/conf/config.ldif
 


### PR DESCRIPTION
Currently if a `config.ldif` file exists in `/bootstrap` and the docker image is restarted the LDAP server will not start complaining about conflicting `config.ldif` and `ou=config` directories.
