### PR TITLE
add BOOTSTRAP_OPTS to specify ldapmodify options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Sample schema can be found in a [sample/schema.tar](2) in this GitHub repository
 If you want to use specific **config.ldif** to setup Apache DS place it in the mounted volume for **/bootstrap** directory. Container will pick it up automaticaly.
 
 If you have some extra data you want to put into Directory, you can place a file in the **/bootstrap** mounting folder and setup Environment variable **BOOTSTRAP_FILE**.
+Further options to the ldapmodify command that will evaluate your bootsrap file can be set with **BOOTSTRAP_OPTS** (e.g. BOOTSTRAP_OPTS=-a for adding new entries). 
 
 	docker run -d -p 10389:10389 -v /onmyhost:/bootstrap -e BOOTSTRAP_FILE=/bootstrap/the-file.ldif greggigon/apacheds
 

--- a/apacheds.sh
+++ b/apacheds.sh
@@ -49,7 +49,7 @@ wait_for_ldap
 if [ -n "${BOOTSTRAP_FILE}" ]; then
 	echo "Bootstraping Apache DS with Data from ${BOOTSTRAP_FILE}"
 	
-	ldapmodify -h localhost -p 10389 -D 'uid=admin,ou=system' -w secret -f $BOOTSTRAP_FILE
+	ldapmodify -h localhost -p 10389 -D 'uid=admin,ou=system' -w secret -f $BOOTSTRAP_FILE $BOOTSTRAP_OPTS
 fi
 
 trap "echo 'Stopping Apache DS';/opt/apacheds-2.0.0_M24/bin/apacheds stop default;exit 0" SIGTERM SIGKILL


### PR DESCRIPTION
Hi Greg,
I faced the same problem as described in #9 (missing the -a flag) and found the suggestion of @sandipchitale very helpful.
Hope this could help other people also...